### PR TITLE
prepare-debian-ubuntu.sh now installs correct packages for these systems

### DIFF
--- a/prepare-debian-ubuntu.sh
+++ b/prepare-debian-ubuntu.sh
@@ -4,4 +4,4 @@
 sudo apt-get install $@ \
   git gzip libarchive-dev libcurl4 libcurl4-openssl-dev libelf-dev libgpgme-dev libncurses5-dev libreadline-dev libssl-dev \
   libtool-bin libusb-dev m4 make patch pkg-config python3 python3-venv subversion tar tcl texinfo unzip wget xz-utils \
-  sudo fakeroot libarchive-tools curl libgmp3-dev libmpfr-dev libmpc-dev python3-pip
+  sudo fakeroot libarchive-tools curl libgmp3-dev libmpfr-dev libmpc-dev python3-pip autoconf automake bison bzip2 cmake doxygen flex g++ gcc

--- a/prepare-debian-ubuntu.sh
+++ b/prepare-debian-ubuntu.sh
@@ -2,6 +2,6 @@
 
 # Install build dependencies
 sudo apt-get install $@ \
-  @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf \
-  libarchive-devel openssl-devel gpgme-devel libtool gettext texinfo bison flex gmp-devel mpfr-devel libmpc-devel ncurses-devel diffutils \
-  libusb-devel
+  git gzip libarchive-dev libcurl4 libcurl4-openssl-dev libelf-dev libgpgme-dev libncurses5-dev libreadline-dev libssl-dev \
+  libtool-bin libusb-dev m4 make patch pkg-config python3 python3-venv subversion tar tcl texinfo unzip wget xz-utils \
+  sudo fakeroot libarchive-tools curl libgmp3-dev libmpfr-dev libmpc-dev python3-pip


### PR DESCRIPTION
prepare-debian-ubuntu.sh tried to install fedora packages (a copy-paste error, most likely), resulting in "package not found" errors. Now the script installs correct packages for Debian & Ubuntu.