### PR TITLE
Add required package fakeroot

### DIFF
--- a/prepare-fedora.sh
+++ b/prepare-fedora.sh
@@ -2,6 +2,6 @@
 
 # Install build dependencies
 sudo dnf install $@ \
-  @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf \
+  @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf fakeroot \
   libarchive-devel openssl-devel gpgme-devel libtool gettext texinfo bison flex gmp-devel mpfr-devel libmpc-devel ncurses-devel diffutils \
   libusb-devel readline-devel


### PR DESCRIPTION
This is required for psp-packages builds but missing from the Fedora
script.