### PR TITLE
Exclude psplinkusb from docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY . /src
 # There are some dependencies needed because it is checked by "depends" scripts
 RUN apk add build-base git bash patch wget zlib-dev ucl-dev readline-dev libusb-compat-dev \
     autoconf automake bison flex python3 py3-pip cmake pkgconfig libarchive-dev openssl-dev gpgme-dev libtool
-RUN cd /src && ./build-extra.sh
+RUN cd /src && ./build-extra.sh 2
 
 # Second stage of Dockerfile
 FROM alpine:latest


### PR DESCRIPTION
This cannot be used from docker and it requires too many dependencies to be used. It's better to just exclude it. I'm still testing this at the moment, so it's still a draft.