### PR TITLE
Add dependencies for psp-gcc and make

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,3 +16,4 @@ ENV PSPDEV /usr/local/pspdev
 ENV PATH $PATH:${PSPDEV}/bin
 
 COPY --from=0 ${PSPDEV} ${PSPDEV}
+RUN apk add gmp mpc1 mpfr4 make

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ENV PSPDEV /usr/local/pspdev
 ENV PATH $PATH:${PSPDEV}/bin
 
 COPY --from=0 ${PSPDEV} ${PSPDEV}
-RUN apk add gmp mpc1 mpfr4 make
+RUN apk add --no-cache gmp mpc1 mpfr4 make


### PR DESCRIPTION
This affects the size of the docker container in the following way based on the installed size for each package found [here](https://pkgs.alpinelinux.org/packages):
- make: 232 kB
- gmp: 416 kB
- mpc1: 108 kB
- mpfr4: 2.61 MB

No other packages will be installed with this change, but psp-gcc will work and make will be available for a size increase of almost 3.5 MB.