### PR TITLE
Add pkg-config to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ENV PSPDEV /usr/local/pspdev
 ENV PATH $PATH:${PSPDEV}/bin
 
 COPY --from=0 ${PSPDEV} ${PSPDEV}
-RUN apk add --no-cache gmp mpc1 mpfr4 make
+RUN apk add --no-cache gmp mpc1 mpfr4 make bash pkgconf


### PR DESCRIPTION
This adds about 1,5 mb to the size of the container, but makes psp-pkg-config able to work.