### PR TITLE
Use relative links instead

### DIFF
--- a/scripts/002-pspsdk.sh
+++ b/scripts/002-pspsdk.sh
@@ -26,13 +26,13 @@ make --quiet -j $PROC_NR clean          || { exit 1; }
 
 ## gcc needs to include libcglue libpthreadglue libpsputility libpsprtc libpspnet_inet libpspnet_resolver libpspsdk libpspmodinfo libpspuser libpspkernel
 ## from pspsdk to be able to build executables, because they are part of the standard libraries
-ln -sf "$PSPDEV/psp/sdk/lib/libcglue.a" "$PSPDEV/psp/lib/libcglue.a" || { exit 1; }
-ln -sf "$PSPDEV/psp/sdk/lib/libpthreadglue.a" "$PSPDEV/psp/lib/libpthreadglue.a" || { exit 1; }
-ln -sf "$PSPDEV/psp/sdk/lib/libpsputility.a" "$PSPDEV/psp/lib/libpsputility.a" || { exit 1; }
-ln -sf "$PSPDEV/psp/sdk/lib/libpsprtc.a" "$PSPDEV/psp/lib/libpsprtc.a" || { exit 1; }
-ln -sf "$PSPDEV/psp/sdk/lib/libpspnet_inet.a" "$PSPDEV/psp/lib/libpspnet_inet.a" || { exit 1; }
-ln -sf "$PSPDEV/psp/sdk/lib/libpspnet_resolver.a" "$PSPDEV/psp/lib/libpspnet_resolver.a" || { exit 1; }
-ln -sf "$PSPDEV/psp/sdk/lib/libpspsdk.a" "$PSPDEV/psp/lib/libpspsdk.a" || { exit 1; }
-ln -sf "$PSPDEV/psp/sdk/lib/libpspmodinfo.a" "$PSPDEV/psp/lib/libpspmodinfo.a" || { exit 1; }
-ln -sf "$PSPDEV/psp/sdk/lib/libpspuser.a" "$PSPDEV/psp/lib/libpspuser.a" || { exit 1; }
-ln -sf "$PSPDEV/psp/sdk/lib/libpspkernel.a" "$PSPDEV/psp/lib/libpspkernel.a" || { exit 1; }
+(cd "$PSPDEV/psp/sdk/lib/" && ln -sf libcglue.a ../../lib/) || { exit 1; }
+(cd "$PSPDEV/psp/sdk/lib/" && ln -sf libpthreadglue.a ../../lib/) || { exit 1; }
+(cd "$PSPDEV/psp/sdk/lib/" && ln -sf libpsputility.a ../../lib/) || { exit 1; }
+(cd "$PSPDEV/psp/sdk/lib/" && ln -sf libpsprtc.a ../../lib/) || { exit 1; }
+(cd "$PSPDEV/psp/sdk/lib/" && ln -sf libpspnet_inet.a ../../lib/) || { exit 1; }
+(cd "$PSPDEV/psp/sdk/lib/" && ln -sf libpspnet_resolver.a ../../lib/) || { exit 1; }
+(cd "$PSPDEV/psp/sdk/lib/" && ln -sf libpspsdk.a ../../lib/) || { exit 1; }
+(cd "$PSPDEV/psp/sdk/lib/" && ln -sf libpspmodinfo.a ../../lib/) || { exit 1; }
+(cd "$PSPDEV/psp/sdk/lib/" && ln -sf libpspuser.a ../../lib/) || { exit 1; }
+(cd "$PSPDEV/psp/sdk/lib/" && ln -sf libpspkernel.a ../../lib/) || { exit 1; }


### PR DESCRIPTION
This is generally better, allows toolchain to be moved around