### PR TITLE
fix usb.h missing

### DIFF
--- a/prepare-arch.sh
+++ b/prepare-arch.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Install build dependencies
-sudo pacman -Sy gcc clang make cmake patch git texinfo flex bison gettext wget gsl gmp mpfr libmpc libusb readline libarchive gpgme bash openssl libtool
+sudo pacman -Sy gcc clang make cmake patch git texinfo flex bison gettext wget gsl gmp mpfr libmpc libusb readline libarchive gpgme bash openssl libtool libusb-compat


### PR DESCRIPTION
on arch linux, libusb does not contain a `usb.h` but rather a `libusb.h`; libusb-compat fixes this, and this pull request adds the package to the install script.