### PR TITLE
fix boost_regex missing

### DIFF
--- a/prepare-arch.sh
+++ b/prepare-arch.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 # Install build dependencies
-sudo pacman -Sy gcc clang make cmake patch git texinfo flex bison gettext wget gsl gmp mpfr libmpc libusb readline libarchive gpgme bash openssl libtool libusb-compat
+sudo pacman -Sy gcc clang make cmake patch git texinfo flex bison gettext wget gsl gmp mpfr libmpc libusb readline libarchive gpgme bash openssl libtool libusb-compat boost


### PR DESCRIPTION
`ld` errors out if `boost_regex` is missing, this fixes that by adding `boost` to the install script
i completely forgot about this when adding the other package