### PR TITLE
Use pacman instead of strange script to install

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -116,7 +116,7 @@ jobs:
       run: |
         dnf -y install @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf \
           libarchive-devel openssl-devel gpgme-devel libtool gettext texinfo bison flex gmp-devel mpfr-devel libmpc-devel ncurses-devel diffutils \
-          libusb-devel readline-devel
+          libusb-devel readline-devel libcurl-devel
 
     - name: Runs all the stages in the shell
       run: |

--- a/scripts/003-psp-packages.sh
+++ b/scripts/003-psp-packages.sh
@@ -1,28 +1,28 @@
 #!/bin/bash
 # psp-packages by fjtrujy
 
-## Download the source code.
-REPO_URL="https://github.com/pspdev/psp-packages"
-REPO_FOLDER="psp-packages"
-BRANCH_NAME="master"
-if test ! -d "$REPO_FOLDER"; then
-	git clone --depth 1 -b $BRANCH_NAME $REPO_URL && cd $REPO_FOLDER || { exit 1; }
-else
-	cd $REPO_FOLDER && git fetch origin && git reset --hard origin/${BRANCH_NAME} || { exit 1; }
-fi
-
-
-# WIndows currently doesn't have pacman, so packages needs to be installed manually
-OSVER=$(uname)
-install_method="pacman"
-if [ "${OSVER:0:5}" == MINGW ]; then
-	install_method="manually"
-fi
-
 if [ -z "$LOCAL_PACKAGE_BUILD" ]; then
-  # Install all packages
-  ./install-latest.sh  "pspdev/psp-packages"  $install_method || { exit 1; }
+	# Install all packages
+	psp-pacman -Sy && psp-pacman -S --noconfirm $(psp-pacman -Slq) || { exit 1; }
 else
-  # Build and install the packages
-  ./build.sh --install
+	## Download the source code.
+	REPO_URL="https://github.com/pspdev/psp-packages"
+	REPO_FOLDER="psp-packages"
+	BRANCH_NAME="master"
+	if test ! -d "$REPO_FOLDER"; then
+		git clone --depth 1 -b $BRANCH_NAME $REPO_URL && cd $REPO_FOLDER || { exit 1; }
+	else
+		cd $REPO_FOLDER && git fetch origin && git reset --hard origin/${BRANCH_NAME} || { exit 1; }
+	fi
+
+
+	# WIndows currently doesn't have pacman, so packages needs to be installed manually
+	OSVER=$(uname)
+	install_method="pacman"
+	if [ "${OSVER:0:5}" == MINGW ]; then
+		install_method="manually"
+	fi
+
+	# Build and install the packages
+	./build.sh --install
 fi


### PR DESCRIPTION
The script which was used before is weird and was making the Mac build fail somehow. It polls the GitHub API, the downloads the package with curl and then installs it with psp-pacman. That's pacman's job and it's very good at it, so I changed it here.