### PR TITLE
Clean up compilation.yml

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -11,41 +11,30 @@ jobs:
     runs-on: ${{ matrix.os[0] }}
     strategy:
       matrix:
-        os: [[macos-latest, bash], [macos-11, bash], [ubuntu-latest, bash], [windows-latest, msys2]]
+        os: [[macos-latest, bash], [ubuntu-latest, bash]]
       fail-fast: false
     defaults:
      run:
       shell: ${{ matrix.os[1] }} {0}
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
 
-    - name: Install Ubuntu texinfo bison flex libucl-dev
-      if: matrix.os[0] == 'ubuntu-latest'
+    - name: Install dependencies on Ubuntu
+      if: startsWith( matrix.os[0], 'ubuntu' )
       run: |
         sudo apt-get update
         sudo apt-get -y install texinfo bison flex gettext libgmp3-dev libmpfr-dev libmpc-dev libusb-dev libreadline-dev libcurl4 libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev
         echo "MSYSTEM=x64" >> $GITHUB_ENV
 
-    - name: Install Mac texinfo bison flex ucl
+    - name: Install dependencies on MacOS
       if: startsWith( matrix.os[0], 'macos' )
       run: |
         brew update
         brew install gettext texinfo bison flex gnu-sed ncurses gsl gmp mpfr autoconf automake cmake libusb-compat libarchive gpgme bash openssl libtool
         echo "MSYSTEM=x64" >> $GITHUB_ENV
 
-    - name: Install in MSYS2
-      if: matrix.os[0] == 'windows-latest'
-      uses: msys2/setup-msys2@v2
-      with:
-        msystem: MINGW32
-        install: |
-          base-devel git make autoconf automake libtool texinfo flex bison patch binutils 
-          mingw-w64-i686-gcc mingw-w64-i686-dlfcn mingw-w64-i686-mpc mingw-w64-i686-cmake
-        update: true
-        shell: msys2 {0}
-
-    - name: Runs all the stages in the shell
+    - name: Runs full build in shell
       run: |
         export PATH="/usr/local/opt/gnu-sed/libexec/gnubin:$PATH"
         export PATH="/usr/local/opt/libtool/libexec/gnubin:$PATH"
@@ -54,26 +43,17 @@ jobs:
         export PATH=$PATH:$PSPDEV/bin
         ./build-all.sh
 
-    - name: Get short SHA
-      id: slug
-      run: echo "::set-output name=sha8::${MSYSTEM}-sha[$(echo ${GITHUB_SHA} | cut -c1-8)]"
-
     - name: Prepare pspdev folder
       run: |
         tar -zcvf pspdev-${{matrix.os[0]}}.tar.gz pspdev
 
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
-        name: pspdev-${{matrix.os[0]}}-${{ steps.slug.outputs.sha8 }}
+        name: pspdev-${{matrix.os[0]}}
         path: pspdev-${{matrix.os[0]}}.tar.gz
 
-    - name: Extract tag name
-      if: startsWith(github.ref, 'refs/tags/')
-      id: tag
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
     - name: Create pre-release
-      if: github.ref == 'refs/heads/master'
+      if: ${{ github.ref == 'refs/heads/main' }}
       uses: softprops/action-gh-release@v1
       with:
         files: pspdev-${{matrix.os[0]}}.tar.gz
@@ -84,80 +64,10 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Release
-      if: startsWith(github.ref, 'refs/tags/')
+      if: ${{ github.ref_type == "tag" }}
       uses: softprops/action-gh-release@v1
       with:
         files: pspdev-${{matrix.os[0]}}.tar.gz
-        tag_name: ${{ steps.tag.outputs.VERSION }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
-  build-Dockers:
-    runs-on: ubuntu-latest
-    container: ${{ matrix.os }}:latest
-    strategy:
-      matrix:
-        os: [ubuntu, fedora]
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Install Ubuntu texinfo bison flex libucl-dev
-      if: matrix.os == 'ubuntu'
-      run: |
-        apt-get -y update
-        DEBIAN_FRONTEND="noninteractive" TZ="Europe/London" apt-get -y install autoconf automake bison bzip2 cmake doxygen flex g++ gcc \
-          git gzip libarchive-dev libcurl4 libcurl4-openssl-dev libelf-dev libgpgme-dev libncurses5-dev libreadline-dev libssl-dev \
-          libtool-bin libusb-dev m4 make patch pkg-config python3 python3-venv subversion tar tcl texinfo unzip wget xz-utils \
-          sudo fakeroot libarchive-tools curl libgmp3-dev libmpfr-dev libmpc-dev python3-pip
-
-    - name: Install dependencies Fedora
-      if: matrix.os == 'fedora'
-      run: |
-        dnf -y install @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf \
-          libarchive-devel openssl-devel gpgme-devel libtool gettext texinfo bison flex gmp-devel mpfr-devel libmpc-devel ncurses-devel diffutils \
-          libusb-devel readline-devel
-
-    - name: Runs all the stages in the shell
-      run: |
-        export PSPDEV=$PWD/pspdev
-        export PATH=$PATH:$PSPDEV/bin
-        ./build-all.sh
-
-    - name: Get short SHA
-      id: slug
-      run: echo "::set-output name=sha8::${MSYSTEM}-sha[$(echo ${GITHUB_SHA} | cut -c1-8)]"
-
-    - name: Prepare pspdev folder
-      run: |
-        tar -zcvf pspdev-${{matrix.os[0]}}.tar.gz pspdev
-
-    - uses: actions/upload-artifact@v2
-      with:
-        name: pspdev-${{matrix.os}}-${{ steps.slug.outputs.sha8 }}
-        path: pspdev-${{matrix.os}}.tar.gz
-
-    - name: Extract tag name
-      if: startsWith(github.ref, 'refs/tags/')
-      id: tag
-      run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-    - name: Create pre-release
-      if: github.ref == 'refs/heads/master'
-      uses: softprops/action-gh-release@v1
-      with:
-        files: pspdev-${{matrix.os}}.tar.gz
-        prerelease: true
-        name: "Development build"
-        tag_name: "latest"
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-    - name: Release
-      if: startsWith(github.ref, 'refs/tags/')
-      uses: softprops/action-gh-release@v1
-      with:
-        files: pspdev-${{matrix.os}}.tar.gz
-        tag_name: ${{ steps.tag.outputs.VERSION }}
+        tag_name: ${{ github.ref_name }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -64,7 +64,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Release
-      if: ${{ github.ref_type == "tag" }}
+      if: ${{ github.ref_type == 'tag' }}
       uses: softprops/action-gh-release@v1
       with:
         files: pspdev-${{matrix.os[0]}}.tar.gz

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -53,7 +53,7 @@ jobs:
         path: pspdev-${{matrix.os[0]}}.tar.gz
 
     - name: Create pre-release
-      if: ${{ github.ref == 'refs/heads/main' }}
+      if: ${{ github.ref == 'refs/heads/master' }}
       uses: softprops/action-gh-release@v1
       with:
         files: pspdev-${{matrix.os[0]}}.tar.gz
@@ -106,7 +106,7 @@ jobs:
         path: pspdev-${{matrix.container[0]}}-${{matrix.container[1]}}.tar.gz
 
     - name: Create pre-release
-      if: ${{ github.ref == 'refs/heads/main' }}
+      if: ${{ github.ref == 'refs/heads/master' }}
       uses: softprops/action-gh-release@v1
       with:
         files: pspdev-${{matrix.container[0]}}-${{matrix.container[1]}}.tar.gz

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -71,3 +71,56 @@ jobs:
         tag_name: ${{ github.ref_name }}
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  build-Dockers:
+    runs-on: ubuntu-latest
+    container: ${{ matrix.container[0] }}:${{ matrix.container[1] }}
+    strategy:
+      matrix:
+        container: [[fedora, latest]]
+      fail-fast: false
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Install dependencies Fedora
+      if: ${{ matrix.container[0] == 'fedora' }}
+      run: |
+        dnf -y install @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf \
+          libarchive-devel openssl-devel gpgme-devel libtool gettext texinfo bison flex gmp-devel mpfr-devel libmpc-devel ncurses-devel diffutils \
+          libusb-devel readline-devel libcurl-devel
+
+    - name: Runs full build in shell
+      run: |
+        export PSPDEV=$PWD/pspdev
+        export PATH=$PATH:$PSPDEV/bin
+        ./build-all.sh
+
+    - name: Prepare pspdev folder
+      run: |
+        tar -zcvf pspdev-${{matrix.container[0]}}-${{matrix.container[1]}}.tar.gz pspdev
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: pspdev-${{matrix.container[0]}}-${{matrix.container[1]}}
+        path: pspdev-${{matrix.container[0]}}-${{matrix.container[1]}}.tar.gz
+
+    - name: Create pre-release
+      if: ${{ github.ref == 'refs/heads/main' }}
+      uses: softprops/action-gh-release@v1
+      with:
+        files: pspdev-${{matrix.container[0]}}-${{matrix.container[1]}}.tar.gz
+        prerelease: true
+        name: "Development build"
+        tag_name: "latest"
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Release
+      if: ${{ github.ref_type == 'tag' }}
+      uses: softprops/action-gh-release@v1
+      with:
+        files: pspdev-${{matrix.container[0]}}-${{matrix.container[1]}}.tar.gz
+        tag_name: ${{ github.ref_name }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
So this is a big change, but I think it would be an improvement. Let me go over the changes:
- Only build for MacOS latest, not 11 and latest. At the moment they were the same anyway,
- Do not build for Windows. Windows would have to use MSYS2 to get the build working on their system and the build time was insane. I'd suggest we tell people to use the Ubuntu builds in WSL. I'm already working on documenting that on pspdev.github.io.
- Do not do the docker builds. Even though they should have been added to the pre-releases and releases. They also seem a bit redundant with the current naming.
- Get rid of some warnings by no longer using set-output and upgrading the checkout and get-artifact actions.

With these changes builds should take significantly less time and be much less wasteful. We should be using about half the resources from GitHub with this. This would also lower the support burden a bit, as keeping the MSYS build working has been a chore.