### PR TITLE
`prepare-fedora.sh`: fix broken package

### DIFF
--- a/prepare-fedora.sh
+++ b/prepare-fedora.sh
@@ -4,4 +4,4 @@
 sudo dnf install $@ \
   @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf fakeroot \
   libarchive-devel openssl-devel gpgme-devel libtool gettext texinfo bison flex gmp-devel mpfr-devel libmpc-devel ncurses-devel diffutils \
-  libusb-devel readline-devel
+  libusb-compat-0.1-devel readline-devel


### PR DESCRIPTION
`libusb-devel` does not exist anymore. The correct package is now `libusb-compat-0.1-devel`.