### PR TITLE
Add cmake to pspdev container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ENV PSPDEV /usr/local/pspdev
 ENV PATH $PATH:${PSPDEV}/bin
 
 COPY --from=0 ${PSPDEV} ${PSPDEV}
-RUN apk add --no-cache gmp mpc1 mpfr4 make bash pkgconf
+RUN apk add --no-cache gmp mpc1 mpfr4 make bash pkgconf cmake


### PR DESCRIPTION
This addresses #40. I feel we should just ship cmake. It's needed to build a lot of software.