### PR TITLE
Install libraries required by pacman in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ENV PSPDEV /usr/local/pspdev
 ENV PATH $PATH:${PSPDEV}/bin
 
 COPY --from=0 ${PSPDEV} ${PSPDEV}
-RUN apk add --no-cache gmp mpc1 mpfr4 make bash pkgconf cmake
+RUN apk add --no-cache gmp mpc1 mpfr4 make bash pkgconf cmake gpgme libcurl


### PR DESCRIPTION
⚠️ **Do not accept this PR until updated pacman is in [BASE_DOCKER_IMAGE](https://ghcr.io/pspdev/psp-packages)!**

After https://github.com/pspdev/psptoolchain-extra/pull/16 is accepted, pacman should be linked against `libgpgme.so.11` and `libcurl.so.4`. This patch installs the packages containing these libraries in the Docker container.