### PR TITLE
Always use latest psp-packages container as base

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -51,4 +51,4 @@ jobs:
         push: true
         tags: ${{ github.repository }}:${{ env.DOCKER_TAG }}
         build-args: |
-          BASE_DOCKER_IMAGE=ghcr.io/${{ github.repository_owner }}/psp-packages:${{ env.DOCKER_TAG }}
+          BASE_DOCKER_IMAGE=ghcr.io/${{ github.repository_owner }}/psp-packages:latest


### PR DESCRIPTION
What we are doing right now is not really working. We should just do releases on the pspdev repo.