### PR TITLE
Add more repos to build.txt

### DIFF
--- a/scripts/004-psplinkusb-extra.sh
+++ b/scripts/004-psplinkusb-extra.sh
@@ -23,3 +23,10 @@ if [ "${OSVER:0:5}" != MINGW ]; then
 	make --quiet -j $PROC_NR -C pspsh install 			|| { exit 1; }
 	make --quiet -j $PROC_NR -C usbhostfs_pc install 	|| { exit 1; }
 fi
+
+## Store build information
+BUILD_FILE="${PSPDEV}/build.txt"
+if [[ -f "${BUILD_FILE}" ]]; then
+  sed -i'' '/^psplinkusb /d' "${BUILD_FILE}"
+fi
+git log -1 --format="psplinkusb %H %cs %s" >> "${BUILD_FILE}"

--- a/scripts/005-ebootsigner-extra.sh
+++ b/scripts/005-ebootsigner-extra.sh
@@ -19,3 +19,10 @@ make --quiet -j $PROC_NR clean          || { exit 1; }
 make --quiet -j $PROC_NR all            || { exit 1; }
 make --quiet -j $PROC_NR install        || { exit 1; }
 make --quiet -j $PROC_NR clean          || { exit 1; }
+
+## Store build information
+BUILD_FILE="${PSPDEV}/build.txt"
+if [[ -f "${BUILD_FILE}" ]]; then
+  sed -i'' '/^ebootsigner /d' "${BUILD_FILE}"
+fi
+git log -1 --format="ebootsigner %H %cs %s" >> "${BUILD_FILE}"


### PR DESCRIPTION
psplinkusb and ebootsigner were still missing. This add those without making changes to these actual repos. Not 100% sure if this is the best approach here. It will work very well for the prebuild toolchain and the docker containers.