### PR TITLE
Create new release at the first of every month

### DIFF
--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -1,0 +1,20 @@
+name: Tag-Release
+
+on:
+  schedule:
+  - cron: 0 17 1 * *
+  repository_dispatch:
+    types: [tag_release]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Tag new release name
+      run: |
+        export TAG="$(date +"v%Y%m%d")"
+        git tag "${TAG}"
+        git push origin "${TAG}"

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        ssh-key: ${{ secrets.DEPLOY_PRIVATE_KEY }}
 
     - name: Tag new release name
       run: |

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch: {}
 
 jobs:
-  build:
+  tag:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/tag.yml
+++ b/.github/workflows/tag.yml
@@ -3,8 +3,7 @@ name: Tag-Release
 on:
   schedule:
   - cron: 0 17 1 * *
-  repository_dispatch:
-    types: [tag_release]
+  workflow_dispatch: {}
 
 jobs:
   build:


### PR DESCRIPTION
Like discussed before, here is the pipeline that will create a new tag which triggers a release each month on the first day. The deployment key has already been created and added to this repo.