### PR TITLE
Always use latest psp-packages container as base container

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -39,7 +39,7 @@ jobs:
         push: true
         tags: ghcr.io/${{ github.repository }}:${{ env.DOCKER_TAG }}
         build-args: |
-          BASE_DOCKER_IMAGE=ghcr.io/${{ github.repository_owner }}/psp-packages:${{ env.DOCKER_TAG }}
+          BASE_DOCKER_IMAGE=ghcr.io/${{ github.repository_owner }}/psp-packages:latest
 
     - name: Login to DockerHub
       uses: docker/login-action@v3


### PR DESCRIPTION
I still forgot one place where it was using a specific tag that won't exist anyway.