### PR TITLE
Install default library packages only

### DIFF
--- a/scripts/003-psp-packages.sh
+++ b/scripts/003-psp-packages.sh
@@ -3,7 +3,7 @@
 
 if [ -z "$LOCAL_PACKAGE_BUILD" ]; then
 	# Install all packages
-	psp-pacman -Sy && psp-pacman -S --noconfirm $(psp-pacman -Slq) || { exit 1; }
+	psp-pacman -Sy && psp-pacman -S --noconfirm pspdev-default || { exit 1; }
 else
 	## Download the source code.
 	REPO_URL="https://github.com/pspdev/psp-packages"


### PR DESCRIPTION
We now have support for conflicting packages in our repo, so we should assume that there will be and only install the default set of packages.