### PR TITLE
Add changelog to releases

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -7,6 +7,28 @@ on:
     types: [run_build]
 
 jobs:
+  prepare-release:
+    runs-on: ubuntu-latest
+    if: ${{ github.ref_type == 'tag' }}
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Install dependencies
+      run: |
+        apt-get update
+        apt-get install -y jq
+    - name: Generate Changelog
+      run: |
+        ./build-changelog.sh > changelog.md
+    - name: Create Release
+      if: ${{ github.ref_type == 'tag' }}
+      uses: softprops/action-gh-release@v2
+      with:
+        body_path: changelog.md
+        make_latest: true
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   build:
     runs-on: ${{ matrix.os[0] }}
     strategy:

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
-    if: ${{ github.ref_type == 'tag' }}
+    if: ${{ (github.ref_type == 'tag') && (github.repository_owner == 'pspdev') }}
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -19,7 +19,11 @@ jobs:
         sudo apt-get install -y jq
     - name: Generate Changelog
       run: |
-        ./build-changelog.sh > changelog.md
+        echo "We are pleased to announce the ${{ github.ref_name }} release of the PSPDEV toolchain, made for homebrew development for the Playstation Portable." > changelog.md
+        echo "" >> changelog.md
+        echo "For information on how to install and use the PSPDEV toolchain, take a look [here](https://pspdev.github.io/)." >> changelog.md
+        echo "" >> changelog.md
+        ./build-changelog.sh >> changelog.md
     - name: Create Release
       if: ${{ github.ref_type == 'tag' }}
       uses: softprops/action-gh-release@v2

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -15,8 +15,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
-        apt-get update
-        apt-get install -y jq
+        sudo apt-get update
+        sudo apt-get install -y jq
     - name: Generate Changelog
       run: |
         ./build-changelog.sh > changelog.md

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -13,10 +13,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - name: Install dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y jq
     - name: Generate Changelog
       run: |
         echo "We are pleased to announce the ${{ github.ref_name }} release of the PSPDEV toolchain, made for homebrew development for the Playstation Portable." > changelog.md

--- a/build-changelog.sh
+++ b/build-changelog.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+# Temporary file for bundling the output before echoing
+OUTPUT_FILE="$(mktemp)"
+
+# All the repos of which changes land in the release
+REPOS="pspdev pspsdk psptoolchain psptoolchain-allegrex psptoolchain-extra psp-packages psplinkusb psp-pacman ebootsigner"
+
+# Get the timestamp and name of the latest release of pspdev/pspdev
+LAST_RELEASE="$(curl -sfL \
+  -H "Accept: application/vnd.github+json" \
+  -H "X-GitHub-Api-Version: 2022-11-28" \
+  -H "Authorization: Bearer USER_ACCESS_TOKEN" \
+  https://api.github.com/repos/pspdev/pspdev/releases/latest)"
+LAST_RELEASE_DATE="$(echo ${LAST_RELEASE}|jq -r '.created_at')"
+LAST_RELEASE_NAME="$(echo ${LAST_RELEASE}|jq -r '.name')"
+
+echo "## Pull Requests Included" > "${OUTPUT_FILE}"
+echo "" >> "${OUTPUT_FILE}"
+echo "Below are the pull requests that were merged since the ${LAST_RELEASE_NAME} release." >> "${OUTPUT_FILE}"
+echo "" >> "${OUTPUT_FILE}"
+
+for REPO in ${REPOS}; do
+  TMP_FILE="$(mktemp)"
+  # Collect the relevant data about the PRs for the current repo that were merged after the lastest release
+  curl -sfL \
+    -H "Accept: application/vnd.github+json" \
+    -H "X-GitHub-Api-Version: 2022-11-28" \
+    https://api.github.com/repos/pspdev/${REPO}/pulls?state=closed | \
+    jq "[.[] | select((.merged_at != null) and (.merged_at >= \"${LAST_RELEASE_DATE}\")) | {merged_at, title, user: .user.login, user_url: .user.html_url, pr_url: .html_url}]" \
+    >> "${TMP_FILE}"
+
+  # If the received PRs is not an empty list, add it to the final output
+  if [[ ! "$(cat ${TMP_FILE})" =~ ^"[]" ]]; then
+    echo "" >> "${OUTPUT_FILE}"
+    echo "###${REPO}" >> "${OUTPUT_FILE}"
+    echo "" >> "${OUTPUT_FILE}"
+    cat "${TMP_FILE}" | jq -r '.[] | "[\(.title)](\(.pr_url)) by [\(.user)](\(.user_url))"' >> "${OUTPUT_FILE}"
+  fi
+  rm "${TMP_FILE}"
+done
+
+cat "${OUTPUT_FILE}"
+rm "${OUTPUT_FILE}"

--- a/build-changelog.sh
+++ b/build-changelog.sh
@@ -34,7 +34,7 @@ for REPO in ${REPOS}; do
   # If the received PRs is not an empty list, add it to the final output
   if [[ ! "$(cat ${TMP_FILE})" =~ ^"[]" ]]; then
     echo "" >> "${OUTPUT_FILE}"
-    echo "###${REPO}" >> "${OUTPUT_FILE}"
+    echo "### ${REPO}" >> "${OUTPUT_FILE}"
     echo "" >> "${OUTPUT_FILE}"
     cat "${TMP_FILE}" | jq -r '.[] | "[\(.title)](\(.pr_url)) by [\(.user)](\(.user_url))"' >> "${OUTPUT_FILE}"
   fi

--- a/build-changelog.sh
+++ b/build-changelog.sh
@@ -12,7 +12,6 @@ REPOS="pspdev pspsdk psptoolchain psptoolchain-allegrex psptoolchain-extra psp-p
 LAST_RELEASE="$(curl -sfL \
   -H "Accept: application/vnd.github+json" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
-  -H "Authorization: Bearer USER_ACCESS_TOKEN" \
   https://api.github.com/repos/pspdev/pspdev/releases/latest)"
 LAST_RELEASE_DATE="$(echo ${LAST_RELEASE}|jq -r '.created_at')"
 LAST_RELEASE_NAME="$(echo ${LAST_RELEASE}|jq -r '.name')"


### PR DESCRIPTION
This adds a script which gets the timestamp of the last release for the pspdev/pspdev repo and then looks into all the repos which affect the build to see if any PRs were merged after that timestamp. Those are then included in the changelog.

I also added a little message about what PSPDEV is and where more info on it can be found.

Here is an example of what it will look like: https://github.com/sharkwouter/pspdev/releases/tag/test4