### PR TITLE
Add missing packages in WSL(Ubuntu 24.04/Debian)

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -23,7 +23,8 @@ else
     ubuntu | debian)
         sudo apt-get update
         sudo apt-get -y install texinfo bison flex gettext libgmp3-dev libmpfr-dev libmpc-dev libusb-dev libreadline-dev libcurl4 \
-	libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev python3-pip python3-venv cmake libncurses-dev automake pkg-config
+	libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev python3-pip python3-venv cmake libncurses-dev automake pkg-config \
+ 	wget
     ;;
     rhel | fedora)
          dnf -y install @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf \

--- a/prepare.sh
+++ b/prepare.sh
@@ -23,7 +23,7 @@ else
     ubuntu | debian)
         sudo apt-get update
         sudo apt-get -y install texinfo bison flex gettext libgmp3-dev libmpfr-dev libmpc-dev libusb-dev libreadline-dev libcurl4 \
-	libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev python3-pip python3-venv cmake libncurses-dev automake
+	libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev python3-pip python3-venv cmake libncurses-dev automake pkg-config
     ;;
     rhel | fedora)
          dnf -y install @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf \

--- a/prepare.sh
+++ b/prepare.sh
@@ -23,7 +23,7 @@ else
     ubuntu | debian)
         sudo apt-get update
         sudo apt-get -y install texinfo bison flex gettext libgmp3-dev libmpfr-dev libmpc-dev libusb-dev libreadline-dev libcurl4 \
-	libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev python3-pip python3-venv cmake libncurses-dev
+	libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev python3-pip python3-venv cmake libncurses-dev automake
     ;;
     rhel | fedora)
          dnf -y install @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf \

--- a/prepare.sh
+++ b/prepare.sh
@@ -22,7 +22,8 @@ else
 
     ubuntu | debian)
         sudo apt-get update
-        sudo apt-get -y install texinfo bison flex gettext libgmp3-dev libmpfr-dev libmpc-dev libusb-dev libreadline-dev libcurl4 libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev python3-pip
+        sudo apt-get -y install texinfo bison flex gettext libgmp3-dev libmpfr-dev libmpc-dev libusb-dev libreadline-dev libcurl4 \
+	libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev python3-pip python3-venv cmake libncurses-dev
     ;;
     rhel | fedora)
          dnf -y install @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf \


### PR DESCRIPTION
These are the missing packages in newly setup of both WSL(Ubuntu 24.04) and Debian and must be added for convenience.

 - python3-venv
 - cmake
 - libncurses-dev
 - automake
 - pkg-config