### PR TITLE
Add linux mint in prepare script

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -20,11 +20,11 @@ else
 
     case $TESTOS in
 
-    ubuntu | debian)
+    ubuntu | linuxmint | debian)
         sudo apt-get update
         sudo apt-get -y install texinfo bison flex gettext libgmp3-dev libmpfr-dev libmpc-dev libusb-dev libreadline-dev libcurl4 \
-	libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev python3-pip python3-venv cmake libncurses-dev automake pkg-config \
- 	wget
+        libcurl4-openssl-dev libssl-dev libarchive-dev libgpgme-dev python3-pip python3-venv cmake libncurses-dev automake pkg-config \
+        wget libtool
     ;;
     rhel | fedora)
          dnf -y install @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf \


### PR DESCRIPTION
This PR adds Linux Mint in the prepare script because it was not detected even though it was debian-based, and also adds the libtool package to smoothly install all.