### PR TITLE
Add git to docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ ENV PSPDEV /usr/local/pspdev
 ENV PATH $PATH:${PSPDEV}/bin
 
 COPY --from=0 ${PSPDEV} ${PSPDEV}
-RUN apk add --no-cache gmp mpc1 mpfr4 make bash pkgconf cmake gpgme libcurl
+RUN apk add --no-cache gmp mpc1 mpfr4 make bash pkgconf cmake gpgme libcurl git


### PR DESCRIPTION
I would say that git is used often enough by developers that it warrants bundling it. It is especially useful when you want to do a recursive checkout through a GitHub workflow, since that fails if git is not installed yet. Let me know what you guys think.