### PR TITLE
compilation.yml: Add linux-arm64 support

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -36,7 +36,8 @@ jobs:
         os: [
           [macos-latest, arm64, bash],
           [macos-13, x86_64, bash],
-          [ubuntu-latest, x86_64, bash]
+          [ubuntu-latest, x86_64, bash],
+          [ubuntu-24.04-arm, arm64, bash]
         ]
       fail-fast: false
     defaults:


### PR DESCRIPTION
This adds support for linux-arm64. I tested this on my Microsoft Surface Pro (and WSL2 using arm64), I was able to compile/run homebrew on my device.