### PR TITLE
Ubuntu ARM64 Runner support

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -36,7 +36,8 @@ jobs:
         os: [
           [macos-latest, arm64, bash],
           [macos-13, x86_64, bash],
-          [ubuntu-latest, x86_64, bash]
+          [ubuntu-latest, x86_64, bash],
+          [ubuntu-latest, arm64, bash]
         ]
       fail-fast: false
     defaults:


### PR DESCRIPTION
Added the arm64 build. 

It outputs the arm64 binaries needed, unable to test as I don't have a Linux arm64 machine :)