### PR TITLE
Fix changelog including changes from previous releases

### DIFF
--- a/build-changelog.sh
+++ b/build-changelog.sh
@@ -13,7 +13,7 @@ LAST_RELEASE="$(curl -sfL \
   -H "Accept: application/vnd.github+json" \
   -H "X-GitHub-Api-Version: 2022-11-28" \
   https://api.github.com/repos/pspdev/pspdev/releases/latest)"
-LAST_RELEASE_DATE="$(echo ${LAST_RELEASE}|jq -r '.created_at')"
+LAST_RELEASE_DATE="$(echo ${LAST_RELEASE}|jq -r '.published_at')"
 LAST_RELEASE_NAME="$(echo ${LAST_RELEASE}|jq -r '.name')"
 
 echo "## Pull Requests Included" > "${OUTPUT_FILE}"


### PR DESCRIPTION
It turns out created_at is not necessarily updated in the api endpoint we use to get the latest release. The published_at is, though.

You can take a look here to confirm:
https://api.github.com/repos/pspdev/pspdev/releases/latest