### PR TITLE
Add Debian build

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -106,11 +106,11 @@ jobs:
       run: |
         dnf -y install git
 
-    - name: Install git on Debian
+    - name: Install git and sudo on Debian
       if: ${{ matrix.container[0] == 'debian' }}
       run: |
         apt-get update
-        apt-get install -y git
+        apt-get install -y git sudo
 
     - uses: actions/checkout@v4
 

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -94,7 +94,10 @@ jobs:
     container: ${{ matrix.container[0] }}:${{ matrix.container[1] }}
     strategy:
       matrix:
-        container: [[fedora, latest]]
+        container: [
+          [fedora, latest],
+          [debian, latest]
+        ]
       fail-fast: false
 
     steps:

--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -106,10 +106,15 @@ jobs:
       run: |
         dnf -y install git
 
+    - name: Install git on Debian
+      if: ${{ matrix.container[0] == 'debian' }}
+      run: |
+        apt-get update
+        apt-get install -y git
+
     - uses: actions/checkout@v4
 
-    - name: Install dependencies Fedora
-      if: ${{ matrix.container[0] == 'fedora' }}
+    - name: Install dependencies
       run: |
         ./prepare.sh
 


### PR DESCRIPTION
It turns out that Ubuntu builds are no longer compatible with Debian stable, so I think it makes sense to add a Debian specific build.