### PR TITLE
Add missing dependencies to Fedora build

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -34,7 +34,7 @@ else
     rhel | fedora)
          dnf -y install @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf \
           libarchive-devel openssl-devel gpgme-devel libtool gettext texinfo bison flex gmp-devel mpfr-devel libmpc-devel ncurses-devel diffutils \
-          libusb-compat-0.1-devel readline-devel libcurl-devel which glibc-gconv-extra xz
+          libusb-compat-0.1-devel readline-devel libcurl-devel which glibc-gconv-extra xz gawk
     ;;
     gentoo)
         emerge --noreplace net-misc/wget dev-vcs/git dev-python/pip sys-apps/fakeroot \

--- a/prepare.sh
+++ b/prepare.sh
@@ -34,7 +34,7 @@ else
     rhel | fedora)
          dnf -y install @development-tools gcc gcc-c++ g++ wget git autoconf automake python3 python3-pip make cmake pkgconf \
           libarchive-devel openssl-devel gpgme-devel libtool gettext texinfo bison flex gmp-devel mpfr-devel libmpc-devel ncurses-devel diffutils \
-          libusb-compat-0.1-devel readline-devel libcurl-devel which glibc-gconv-extra xz gawk
+          libusb-compat-0.1-devel readline-devel libcurl-devel which glibc-gconv-extra xz gawk file
     ;;
     gentoo)
         emerge --noreplace net-misc/wget dev-vcs/git dev-python/pip sys-apps/fakeroot \


### PR DESCRIPTION
This seems to be one of the reasons it is failing. The other reason it fails still needs  fix. It seems there are issues with building with gcc 15.