### PR TITLE
Fix `usbhostfs_pc` missing `libusb-0.1.so.4` in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -48,4 +48,5 @@ RUN apk add --no-cache \
       cmake \
       gpgme \
       libcurl \
-      git
+      git \
+      libusb-compat

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,33 @@
 ARG BASE_DOCKER_IMAGE
 
-FROM $BASE_DOCKER_IMAGE
+FROM $BASE_DOCKER_IMAGE AS builder
 
 COPY . /src
 
 # There are some dependencies needed because it is checked by "depends" scripts
-RUN apk add build-base git bash patch wget zlib-dev ucl-dev readline-dev libusb-compat-dev \
-    autoconf automake bison flex python3 py3-pip cmake pkgconfig libarchive-dev openssl-dev gpgme-dev libtool
+RUN apk add \
+      build-base \
+      git \
+      bash \
+      patch \
+      wget \
+      zlib-dev \
+      ucl-dev \
+      readline-dev \
+      libusb-compat-dev \
+      autoconf \
+      automake \
+      bison \
+      flex \
+      python3 \
+      py3-pip \
+      cmake \
+      pkgconfig \
+      libarchive-dev \
+      openssl-dev \
+      gpgme-dev \
+      libtool
+
 RUN cd /src && ./build-extra.sh
 
 # Second stage of Dockerfile
@@ -15,5 +36,16 @@ FROM alpine:latest
 ENV PSPDEV /usr/local/pspdev
 ENV PATH $PATH:${PSPDEV}/bin
 
-COPY --from=0 ${PSPDEV} ${PSPDEV}
-RUN apk add --no-cache gmp mpc1 mpfr4 make bash pkgconf cmake gpgme libcurl git
+COPY --from=builder ${PSPDEV} ${PSPDEV}
+
+RUN apk add --no-cache \
+      gmp \
+      mpc1 \
+      mpfr4 \
+      make \
+      bash \
+      pkgconf \
+      cmake \
+      gpgme \
+      libcurl \
+      git


### PR DESCRIPTION
When running `usbhostfs_pc`, I got greeted with:

```
➜ docker run --rm -it --privileged pspdev:latest                                                     
/ # usbhostfs_pc
Error loading shared library libusb-0.1.so.4: No such file or directory (needed by /usr/local/pspdev/bin/usbhostfs_pc)
Error relocating /usr/local/pspdev/bin/usbhostfs_pc: usb_bulk_write: symbol not found
Error relocating /usr/local/pspdev/bin/usbhostfs_pc: usb_find_busses: symbol not found
Error relocating /usr/local/pspdev/bin/usbhostfs_pc: usb_init: symbol not found
Error relocating /usr/local/pspdev/bin/usbhostfs_pc: usb_find_devices: symbol not found
Error relocating /usr/local/pspdev/bin/usbhostfs_pc: usb_open: symbol not found
Error relocating /usr/local/pspdev/bin/usbhostfs_pc: usb_get_busses: symbol not found
Error relocating /usr/local/pspdev/bin/usbhostfs_pc: usb_reset: symbol not found
Error relocating /usr/local/pspdev/bin/usbhostfs_pc: usb_release_interface: symbol not found
Error relocating /usr/local/pspdev/bin/usbhostfs_pc: usb_close: symbol not found
Error relocating /usr/local/pspdev/bin/usbhostfs_pc: usb_set_configuration: symbol not found
Error relocating /usr/local/pspdev/bin/usbhostfs_pc: usb_bulk_read: symbol not found
Error relocating /usr/local/pspdev/bin/usbhostfs_pc: usb_claim_interface: symbol not found
```

This PR installs the missing `libusb-compat` package in the final stage.

Bonus: Dockerfile formatting.