### PR TITLE
add endeavour os into prepare.sh

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -41,7 +41,7 @@ else
                                         app-arch/libarchive app-crypt/gpgme sys-devel/bison sys-devel/flex\
                                         dev-libs/mpc dev-libs/libusb-compat
     ;;
-    arch | manjaro)
+    arch | manjaro | endeavouros)
         pacman -Sy gcc clang make cmake patch git texinfo flex bison gettext wget gsl gmp mpfr libmpc libusb readline libarchive gpgme bash openssl libtool libusb-compat boost python-pip
     ;;
     opensuse*)


### PR DESCRIPTION
Because EndeavourOS is an arch fork, it should be added into prepare.sh after `arch | manjaro`