### PR TITLE
Build on Fedora 41 instead of 42

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       matrix:
         container: [
-          [fedora, latest],
+          [fedora, 41],
           [debian, latest]
         ]
       fail-fast: false


### PR DESCRIPTION
Right now our builds are failing, because the latest Fedora container cannot build binutils, because our version cannot be build with gcc 15. Downgrading to Fedora 41 should resolve this issue. This should be seen as a temporary solution until we manage to upgrade binutils to a version that does build on Fedora 42.