### PR TITLE
Build for Fedora latest

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -95,7 +95,7 @@ jobs:
     strategy:
       matrix:
         container: [
-          [fedora, 41],
+          [fedora, latest],
           [debian, latest]
         ]
       fail-fast: false


### PR DESCRIPTION
The reason we had to downgrade was that our binutils did not build with gcc 15, which is the default for Fedora. Now that binutils are upgraded, we might be able to build for Fedora latest (42) again.