### PR TITLE
Added Ubuntu 22.04 to CI

### DIFF
--- a/.github/workflows/compilation.yml
+++ b/.github/workflows/compilation.yml
@@ -37,6 +37,7 @@ jobs:
           [macos-latest, arm64, bash],
           [macos-13, x86_64, bash],
           [ubuntu-latest, x86_64, bash],
+          [ubuntu-22.04, x86_64, bash],
           [ubuntu-24.04-arm, arm64, bash]
         ]
       fail-fast: false


### PR DESCRIPTION
## Re-added Ubuntu 22.04 to GitHub Actions

Ubuntu 24.04 (ubuntu-latest in actions) uses GLIBC 2.38 by default, which not all distributions support out of the box, including Debian latest/stable. Re-adding Ubuntu 22.04 ensures better toolchain compatibility and supports users with not latest operating systems.