### PR TITLE
Update prepare.sh

### DIFF
--- a/prepare.sh
+++ b/prepare.sh
@@ -7,7 +7,14 @@ if [ "$(uname -s)" = "Darwin" ]; then
   ## Check if using brew
   if command -v brew &> /dev/null; then
     brew update
-    brew install gettext texinfo bison flex gnu-sed ncurses gsl gmp mpfr autoconf automake cmake libusb libarchive gpgme bash openssl libtool zlib
+    brew install \
+    gettext texinfo bison \
+    flex gnu-sed ncurses \
+    gsl gmp mpfr \
+    autoconf automake cmake \
+    libusb libarchive gpgme \
+    bash openssl libtool \
+    zlib libmpc
     brew reinstall openssl # https://github.com/Homebrew/homebrew-core/issues/169728#issuecomment-2074958306
   fi
   ## Check if using MacPorts


### PR DESCRIPTION
Fix macOS dyld error when running `psp-gcc`.

The compiler backend `cc1` was failing because it expected `libmpc.3.dylib` under the Homebrew Apple Silicon prefix:

```text
dyld: Library not loaded: /opt/homebrew/opt/libmpc/lib/libmpc.3.dylib
  Referenced from: <pspdev>/libexec/gcc/psp/15.2.0/cc1
  Reason: tried: '/opt/homebrew/opt/libmpc/lib/libmpc.3.dylib' (no such file)
psp-gcc: internal compiler error: Abort trap: 6 signal terminated program cc1
```

This updates the macOS dependency setup so the toolchain can find the required Homebrew runtime library.