### PR TITLE
Install psp-libraries package group

### DIFF
--- a/scripts/003-psp-packages.sh
+++ b/scripts/003-psp-packages.sh
@@ -3,7 +3,7 @@
 
 if [ -z "$LOCAL_PACKAGE_BUILD" ]; then
 	# Install all packages
-	psp-pacman -Sy && psp-pacman -S --noconfirm pspdev-default || { exit 1; }
+	psp-pacman -Sy && psp-pacman -S --noconfirm psp-libraries || { exit 1; }
 else
 	## Download the source code.
 	REPO_URL="https://github.com/pspdev/psp-packages"


### PR DESCRIPTION
The pspdev-default will be renamed in https://github.com/pspdev/psp-packages/pull/303